### PR TITLE
Minor Fix

### DIFF
--- a/PowerYaml.psm1
+++ b/PowerYaml.psm1
@@ -63,6 +63,9 @@ function Import-Yaml {
     )
  
     Process {   
+        # Resolve relative paths -> http://stackoverflow.com/a/3040982/3067642
+        # Credits to MVP Oisin 
+        $Fullname = $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath($FullName)
         [System.IO.File]::ReadAllText($FullName) | ConvertFrom-Yaml        
     }
 }


### PR DESCRIPTION
Fixed the case using Oisin's trick at SO, where somebody could pass a
relative name to the Import-Yaml:

```
PS>Import-Yaml .\test.yaml
#This blew up
PS>gc .\test.yaml
# YAML

---
# Document which stores the HyperV host details - stuff needed on
Hyper-V side
HyperVHost: WIN-ETSHC5S9VH9
NetworkRange: 192.168.1.0/24
VMSwitchName: lab
PS>import-yaml .\test.yaml

HyperVHost      NetworkRange   VMSwitchName
----------      ------------   ------------
WIN-ETSHC5S9VH9 192.168.1.0/24 lab
```
